### PR TITLE
Adhere the reflect APIs to the new service changes

### DIFF
--- a/reflect-ballerina/build.gradle
+++ b/reflect-ballerina/build.gradle
@@ -128,15 +128,20 @@ task ballerinaTest {
         debugParams = "--debug ${project.findProperty("debug")}"
     }
 
+    def balJavaDebugParam = ""
+    if (project.hasProperty("balJavaDebug")) {
+        balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
+    }
+
     doLast {
         exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             environment "STDLIB_VERSION", tomlVersion
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/ballerina.bat test ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina test ${debugParams}"
+                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/ballerina test ${debugParams}"
             }
         }
     }

--- a/reflect-ballerina/tests/reflect_test.bal
+++ b/reflect-ballerina/tests/reflect_test.bal
@@ -101,13 +101,10 @@ public function testServiceAnnotationWitSeparateModuleName() {
     test:assertTrue(isExpectedAnnotation, "Returned annotation mismatch");
 }
 
-@test:Config {
-    dependsOn: ["testServiceAnnotationWitSeparateModuleName"],
-    enable: false
-}
+@test:Config {}
 public function testResourceAnnotations() {
     string moduleNameWithVersion = MODULE_NAME + COLON + config:getAsString("STDLIB_VERSION");
-    Annotation? annot = <Annotation?> getResourceAnnotations(ser, "res", resourceAnnotationValue, moduleNameWithVersion);
+    Annotation? annot = <Annotation?> getResourceAnnotations(ser, "processRequest", resourceAnnotationValue, moduleNameWithVersion);
     boolean isExpectedAnnotation = false;
     if (annot is Annotation && resourceAnnotationValue == annot.foo) {
         isExpectedAnnotation = true;

--- a/reflect-native/src/main/java/org/ballerinalang/stdlib/reflect/AnnotationUtils.java
+++ b/reflect-native/src/main/java/org/ballerinalang/stdlib/reflect/AnnotationUtils.java
@@ -19,9 +19,10 @@
 package org.ballerinalang.stdlib.reflect;
 
 import io.ballerina.runtime.api.utils.StringUtils;
-import io.ballerina.runtime.api.types.MemberFunctionType;
+import io.ballerina.runtime.api.types.ResourceFunctionType;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.types.ServiceType;
 
 /**
  * Utility class represents annotation related functionality.
@@ -39,10 +40,11 @@ public class AnnotationUtils {
      * @return annotation value object.
      */
     public static Object externGetResourceAnnotations(BObject service, BString resourceName, BString annot) {
-        MemberFunctionType[] functions = service.getType().getAttachedFunctions();
+        ServiceType serviceType = (ServiceType) service.getType();
+        ResourceFunctionType[] functions = serviceType.getResourceFunctions();
 
-        for (MemberFunctionType function : functions) {
-            if (function.getName().equals(resourceName.getValue())) {
+        for (ResourceFunctionType function : functions) {
+            if (function.getName().equals("$" + function.getAccessor().strip() + "$" + resourceName.getValue().strip())) {
                 Object resourceAnnotation = function.getAnnotation(annot);
                 if (resourceAnnotation instanceof String) {
                     return StringUtils.fromString((String) resourceAnnotation);
@@ -61,7 +63,8 @@ public class AnnotationUtils {
      * @return annotation value object.
      */
     public static Object externGetServiceAnnotations(BObject service, BString annot) {
-        Object serviceAnnotation = service.getType().getAnnotation(annot);
+        ServiceType serviceType = (ServiceType) service.getType();
+        Object serviceAnnotation = serviceType.getAnnotation(annot);
         if (serviceAnnotation instanceof String) {
             return StringUtils.fromString((String) serviceAnnotation);
         }


### PR DESCRIPTION
## Purpose
$title

## Samples
### Read resource annotations
```ballerina
type Annotation record {
    string foo;
    int bar?;
};

annotation Annotation serviceAnnotation on service;
annotation Annotation resourceAnnotation on function;

string serviceAnnotationValue = "serviceAnnotation";
string resourceAnnotationValue = "resourceAnnotation";

type S service object {
    resource function get processRequest() returns json;
};

service object {} ser = @serviceAnnotation{foo: serviceAnnotationValue}
service object {
    @resourceAnnotation{foo: resourceAnnotationValue}
    resource function get processRequest() returns json {
        return { output: "Hello" };
    }
};

// Read API for resources
Annotation? annot = <Annotation?> reflect:getResourceAnnotations(ser, "processRequest", resourceAnnotationValue, moduleNameWithVersion);
```

## Test environment
- Java 11
- SLP8